### PR TITLE
update code for clone

### DIFF
--- a/class/Files/CreateXoopsCode.php
+++ b/class/Files/CreateXoopsCode.php
@@ -1800,15 +1800,17 @@ class CreateXoopsCode
     /**
      * @public  function getXcCommonPagesClone
      * @param        $tableName
+     * @param        $fieldId
      * @param        $ccFieldId
      * @param string $t
      * @param string $language
      * @return string
      */
-    public function getXcCommonPagesClone($tableName, $ccFieldId, string $t = '', string $language = ''): string
+    public function getXcCommonPagesClone($tableName, $fieldId, $ccFieldId, string $t = '', string $language = ''): string
     {
         $pc = Modulebuilder\Files\CreatePhpCode::getInstance();
         $xc = Modulebuilder\Files\CreateXoopsCode::getInstance();
+        $cf = Modulebuilder\Files\CreateFile::getInstance();
 
         $ret = $pc->getPhpCodeCommentLine('Get Form', null, "\t\t");
         $ret .= $xc->getXcHandlerGet($tableName, $ccFieldId . 'Source', 'ObjSource', $tableName . 'Handler', false, $t);
@@ -1816,6 +1818,8 @@ class CreateXoopsCode
         $redirectError      = $xc->getXcRedirectHeader($tableName, '', '3', "{$language}INVALID_PARAM", true, $t . "\t");
         $ret                .= $pc->getPhpCodeConditions('!' . $tablenameObj, '', '', $redirectError, false, $t);
         $ret .= $xc->getXcEqualsOperator('$' . $tableName . 'Obj', '$' . $tableName . 'ObjSource->xoopsClone()', null, $t);
+        $ret .= $cf->getSimpleString('$' . $tableName . 'Obj->setNew();', "\t\t");
+        $ret .= $this->getXcSetVarObj($tableName, $fieldId, 0, "\t\t");
         $ret .= $xc->getXcGetForm('form', $tableName, 'Obj', $t);
         $ret .= $xc->getXcXoopsTplAssign('form', '$form->render()', true, $t);
 

--- a/class/Files/User/UserPages.php
+++ b/class/Files/User/UserPages.php
@@ -475,7 +475,7 @@ class UserPages extends Files\CreateFile
         $ret    .= $this->pc->getPhpCodeCommentLine('Check params', '', $t);
         $contIf = $this->xc->getXcRedirectHeader($tableName, '?op=list', 3, "{$language}INVALID_PARAM", true, $t . "\t");
         $ret    .= $this->pc->getPhpCodeConditions("\${$ccFieldId}Source", ' == ', '0', $contIf, false, $t);
-        $ret    .= $this->xc->getXcCommonPagesClone($tableName, $ccFieldId, $t, $language);
+        $ret    .= $this->xc->getXcCommonPagesClone($tableName, $fieldId, $ccFieldId, $t, $language);
 
         return $ret;
     }

--- a/class/Files/admin/AdminPages.php
+++ b/class/Files/admin/AdminPages.php
@@ -244,7 +244,7 @@ class AdminPages extends Files\CreateFile
         $contIf = $this->xc->getXcRedirectHeader($tableName, '?op=list', 3, "{$language}INVALID_PARAM", true, $t . "\t");
         $ret    .= $this->pc->getPhpCodeConditions("\${$ccFieldId}Source", ' === ', '0', $contIf, false, $t);
 
-        $ret .= $this->xc->getXcCommonPagesClone($tableName, $ccFieldId, $t, $language);
+        $ret .= $this->xc->getXcCommonPagesClone($tableName, $fieldId, $ccFieldId, $t, $language);
 
         return $ret;
     }


### PR DESCRIPTION
## Summary by Sourcery

Update clone page generation to correctly reset identifiers when cloning objects.

Bug Fixes:
- Ensure cloned objects are marked as new and have their identifier fields reset during clone page generation.

Enhancements:
- Extend common clone page helper to accept both primary field ID and clone-control field ID and propagate this to user and admin pages.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved clone operation handling to ensure proper object initialization and field management across user and admin sections.
  * Enhanced consistency in how cloned objects are created and configured throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->